### PR TITLE
Make log file extension customizable, keep ".log" as default

### DIFF
--- a/SwiftLoggly/Sources/Loggly.swift
+++ b/SwiftLoggly/Sources/Loggly.swift
@@ -149,8 +149,17 @@ public enum LogFormatType {
     //The date format of the log time.
     open var logDateFormat = "";
     
+    // Help to enble Emojis
+    open var enableEmojis = false;
+    
+    
+    
     // Log file extension
     open var logFileExtension = ".log"
+    
+    func getExtension() -> String {
+        return logFileExtension.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines).length > 0 ? logFileExtension : ".log"
+    }
     
     ///logging singleton
     open class var logger: Loggly {
@@ -559,7 +568,7 @@ public enum LogFormatType {
             logJson.setValue(text, forKey: "LogMessage")
             return "\(logJson.jsonString.replacingOccurrences(of: "\n", with: ""))\(isDelimiter ?"\n":"")"
         }
-        return "[\(logTypeName(type, isEmojis: false)) \(dateStr)]: \(text)\(isDelimiter ?"\n":"")"
+        return "[\(logTypeName(type, isEmojis: enableEmojis)) \(dateStr)]: \(text)\(isDelimiter ?"\n":"")"
     }
     
     ///write content to the current log file.
@@ -635,7 +644,7 @@ public enum LogFormatType {
     
     ///gets the log name
     func logName(_ num :Int) -> String {
-        return "\(name)-\(num)\(logFileExtension)"
+        return "\(name)-\(num)\(getExtension())"
     }
     
     ///get the default log directory

--- a/SwiftLoggly/Sources/Loggly.swift
+++ b/SwiftLoggly/Sources/Loggly.swift
@@ -149,6 +149,8 @@ public enum LogFormatType {
     //The date format of the log time.
     open var logDateFormat = "";
     
+    // Log file extension
+    open var logFileExtension = ".log"
     
     ///logging singleton
     open class var logger: Loggly {
@@ -633,7 +635,7 @@ public enum LogFormatType {
     
     ///gets the log name
     func logName(_ num :Int) -> String {
-        return "\(name)-\(num).log"
+        return "\(name)-\(num)\(logFileExtension)"
     }
     
     ///get the default log directory


### PR DESCRIPTION
Let the user decides what extension use. For me, .txt is better for readability on some platforms.

Note: Keeping ".log" as default extension